### PR TITLE
Add a transparent left border to non-hover state of dt-app-menu-item :host so that there is no shift to the right when the border appears (or left when it disappears) 

### DIFF
--- a/resources/js/components/app-menu-item.js
+++ b/resources/js/components/app-menu-item.js
@@ -8,6 +8,10 @@ export class AppMenuItem extends MenuItem {
         return [
             super.styles,
             css`
+                :host {
+                  border-left: 2px solid transparent; /* Transparent border in non-hover state */
+                  transition: border-color 0.3s ease; /* Smooth transition for the border color */
+                }
                 :host(:hover) {
                     background-color: hsl(209, 72%, 87%);
                     border-left: 2px solid hsla(221, 94%, 47%, 1);


### PR DESCRIPTION
Add transparent left border to dt-app-menu-item :host in non-hover state to prevent shift on hover. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208192580410471