### PR TITLE
implemented the add query params

### DIFF
--- a/resources/js/components/app-grid.js
+++ b/resources/js/components/app-grid.js
@@ -192,8 +192,8 @@ class AppGrid extends LitElement {
                     break
                 case 'Web View':
                     this.visitApp(
-                        magic_url(`/app/${selectedApp.slug}`),
-                        selectedApp
+                      this.addOrUpdateQueryParam(magic_url(`/app/${selectedApp.slug}`), 'dt_home', 'true'),
+                      selectedApp
                     )
                     break
             }
@@ -207,7 +207,11 @@ class AppGrid extends LitElement {
             window.location.href = url
         }
     }
-
+    addOrUpdateQueryParam(url, key, value) {
+    let urlObj = new URL(url)
+    urlObj.searchParams.set(key, value)
+    return urlObj.toString()
+    }
     /**
      * Handles a double click event on an app.
      * @param event

--- a/src/Controllers/MagicLink/AppController.php
+++ b/src/Controllers/MagicLink/AppController.php
@@ -57,13 +57,40 @@ class AppController
 
         //Check to see if the app has an iframe URL
         $url = apply_filters( 'dt_home_webview_url', $app['url'] ?? '', $app );
-
+        $url = $this->addOrUpdateQueryParam( $url, 'dt_home', 'true' );
         if ( !$url ) {
             //No URL found 404
             return response( __( 'Not Found', 'dt_home' ), 404 );
         }
 
         return template( 'web-view', compact( 'app', 'url' ) );
+    }
+    /**
+     * Adds or updates a query parameter in a URL.
+     *
+     * @param string $url The original URL.
+     * @param string $key The query parameter key.
+     * @param string $value The query parameter value.
+     *
+     * @return string The updated URL.
+     */
+    private function addOrUpdateQueryParam( $url, $key, $value )
+    {
+        // Split the URL into the base and the query string
+        $url_parts = explode( '?', $url, 2 );
+        $base_url = $url_parts[0];
+        $query_string = $url_parts[1] ?? '';
+
+        // Parse the query string into an associative array
+        parse_str( $query_string, $query_params );
+
+        // Update the query parameters
+        $query_params[$key] = $value;
+
+        // Rebuild the query string
+        $new_query_string = http_build_query( $query_params );
+
+        return $base_url . '?' . $new_query_string;
     }
 
     /**


### PR DESCRIPTION
 @incraigulous, I have simplified the addOrUpdateQueryParam function by eliminating the need for parse_url() and http_build_url(). Now, the URL is split using explode() to separate the base and query string, and the query parameters are updated and rebuilt directly with http_build_query(). This approach reduces complexity and improves readability.