### PR TITLE
Remove dt from the hamburger

### DIFF
--- a/resources/css/admin.css
+++ b/resources/css/admin.css
@@ -75,9 +75,11 @@ body {
     transform: translateY(0); /* Smooth appearance */
 
 }
-.tooltip:hover{
+
+.tooltip:hover {
     z-index: auto !important;
 }
+
 .tooltip .tooltiptext::after {
     z-index: auto;
     content: '';
@@ -88,4 +90,19 @@ body {
     border-width: 5px;
     border-style: solid;
     border-color: #333 transparent transparent transparent; /* Creates a small triangle pointing downwards */
+}
+
+/* Mobile responsiveness */
+@media (max-width: 600px) {
+    .tooltip .tooltiptext {
+        /* Adjust width for smaller screens */
+        left: 0%; /* Center the tooltip */
+        margin-left: 0; /* Remove negative margin */
+        bottom: 120%; /* Adjust position above the text */
+    }
+
+    .tooltip .tooltiptext::after {
+        left: 10%;
+        margin-left: -5px; /* Center the arrow */
+    }
 }

--- a/resources/views/layouts/plugin.php
+++ b/resources/views/layouts/plugin.php
@@ -15,9 +15,9 @@ $menu_items[] = [ 'label' => __( 'Log Out', 'dt_home' ), 'href' => magic_url( 'l
 //}
 
 // Adding additional menu item based on user capability
-if ( $user->has_cap( 'access_disciple_tools' ) ) {
-    $menu_items[] = [ 'label' => __( 'Disciple.Tools', 'dt_home' ), 'href' => $dashboard ];
-}
+//if ( $user->has_cap( 'access_disciple_tools' ) ) {
+//    $menu_items[] = [ 'label' => __( 'Disciple.Tools', 'dt_home' ), 'href' => $dashboard ];
+//}
 $menu_items_json = wp_json_encode( $menu_items );
 ?>
 
@@ -33,7 +33,7 @@ $menu_items_json = wp_json_encode( $menu_items );
 
                 <?php
                 // phpcs:ignore
-                echo $this->section( 'content' ) ?>
+                echo $this->section('content') ?>
             </div>
         </div>
 
@@ -41,7 +41,7 @@ $menu_items_json = wp_json_encode( $menu_items );
             <div class="container">
                 <?php
                 // phpcs:ignore
-                echo $this->section( 'footer' ) ?>
+                echo $this->section('footer') ?>
             </div>
         </div>
     </div>

--- a/resources/views/layouts/plugin.php
+++ b/resources/views/layouts/plugin.php
@@ -14,10 +14,7 @@ $menu_items[] = [ 'label' => __( 'Training', 'dt_home' ), 'href' => magic_url( '
 $menu_items[] = [ 'label' => __( 'Log Out', 'dt_home' ), 'href' => magic_url( 'logout' ) ];
 //}
 
-// Adding additional menu item based on user capability
-//if ( $user->has_cap( 'access_disciple_tools' ) ) {
-//    $menu_items[] = [ 'label' => __( 'Disciple.Tools', 'dt_home' ), 'href' => $dashboard ];
-//}
+
 $menu_items_json = wp_json_encode( $menu_items );
 ?>
 

--- a/src/Apps/DiscipleTools.php
+++ b/src/Apps/DiscipleTools.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DT\Home\Apps;
+
+class DiscipleTools extends App
+{
+    public function config(): array
+    {
+        return [
+            "name" => "Disciple Tools",
+            "type" => "Web View",
+            'creation_type' => 'code',
+            "icon" => "/wp-content/themes/disciple-tools-theme/dt-assets/images/dt-caret.png",
+            'url' => site_url( '/' ),
+            "sort" => 0,
+            "slug" => "disciple-tools",
+            "is_hidden" => false,
+            'open_in_new_tab' => false
+        ];
+    }
+
+
+    public function authorized(): bool
+    {
+        // Implement the authorization logic here
+        return true;
+    }
+}

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -4,24 +4,28 @@ namespace DT\Home\Providers;
 
 use DT\Home\Apps\Autolink;
 use DT\Home\Apps\BiblePlugin;
+use DT\Home\Apps\DiscipleTools;
 use DT\Home\Apps\ThreeThirdsMeetings;
 use DT\Home\Conditions\Plugin as IsPlugin;
 use DT\Home\League\Container\ServiceProvider\AbstractServiceProvider;
 use DT\Home\League\Container\ServiceProvider\BootableServiceProviderInterface;
 
-class AppServiceProvider extends AbstractServiceProvider implements BootableServiceProviderInterface {
-	protected $apps = [
-		Autolink::class,
-		BiblePlugin::class,
-		ThreeThirdsMeetings::class
-	];
+class AppServiceProvider extends AbstractServiceProvider implements BootableServiceProviderInterface
+{
+    protected $apps = [
+        Autolink::class,
+        BiblePlugin::class,
+        ThreeThirdsMeetings::class,
+        DiscipleTools::class,
+    ];
 
-	public function boot(): void {
-		foreach ( $this->apps as $app ) {
-			$this->getContainer()->add( $app );
+    public function boot(): void
+    {
+        foreach ( $this->apps as $app ) {
+            $this->getContainer()->add( $app );
             $this->getContainer()->get( $app );
-		}
-	}
+        }
+    }
 
     public function provides( string $id ): bool
     {


### PR DESCRIPTION
@incraigulous , I've completed the task of removing the Disciple Tool (DT) from the hamburger menu and added it as a separate coded app, allowing Admins to control its visibility or use it as a web view.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208217663657694