### PR TITLE
Auto Registering Magic Link Apps

### DIFF
--- a/src/Services/Apps.php
+++ b/src/Services/Apps.php
@@ -65,30 +65,23 @@ class Apps {
                 if ( empty( $app['meta']['show_in_home_apps'] ) ){
                     continue;
                 }
-                if ( $app['post_type'] === 'user' ){
-                    $app_link = get_magic_url( $app['root'], $app['type'], get_current_user_id(), false );
-                }
-                if ( $app['post_type'] === 'contacts' ){
-                    $app_link = get_magic_url( $app['root'], $app['type'], \Disciple_Tools_Users::get_contact_for_user( get_current_user_id() ), false );
-                }
-                if ( !empty( $app_link ) ) {
-                    $apps[$app['type']] = array_merge( [
-                        'name' => $app['label'],
-                        'type' => 'Link',
-                        'creation_type' => 'code',
-                        'icon' => $app['meta']['icon'] ?? '/wp-content/themes/disciple-tools-theme/dt-assets/images/link.svg',
-                        'url' => $app_link,
-                        'slug' => $app['type'],
-                        'sort' => $app['sort'] ?? 10,
-                        'is_hidden' => false,
-                        'open_in_new_tab' => true,
-                        'magic_link_meta' => [
-                            'post_type' => $app['post_type'],
-                            'root' => $app['root'],
-                            'type' => $app['type']
-                        ]
-                    ], $apps[$app['type']] ?? [] );
-                }
+
+                $apps[$app['type']] = array_merge( [
+                    'name' => $app['label'],
+                    'type' => 'Link',
+                    'creation_type' => 'code',
+                    'icon' => $app['meta']['icon'] ?? '/wp-content/themes/disciple-tools-theme/dt-assets/images/link.svg',
+                    'url' => trailingslashit( trailingslashit( site_url() ) . $app['url_base'] ),
+                    'slug' => $app['type'],
+                    'sort' => $app['sort'] ?? 10,
+                    'is_hidden' => false,
+                    'open_in_new_tab' => true,
+                    'magic_link_meta' => [
+                        'post_type' => $app['post_type'],
+                        'root' => $app['root'],
+                        'type' => $app['type']
+                    ]
+                ], $apps[$app['type']] ?? [] );
             }
         }
 		// Sort the array based on the 'sort' key

--- a/src/Services/Apps.php
+++ b/src/Services/Apps.php
@@ -66,20 +66,29 @@ class Apps {
                     continue;
                 }
                 if ( $app['post_type'] === 'user' ){
-                    $app_link = get_magic_url( $app['root'], $app['type'], get_current_user_id() );
+                    $app_link = get_magic_url( $app['root'], $app['type'], get_current_user_id(), false );
                 }
                 if ( $app['post_type'] === 'contacts' ){
-                    $app_link = get_magic_url( $app['root'], $app['type'], \Disciple_Tools_Users::get_contact_for_user( get_current_user_id() ) );
+                    $app_link = get_magic_url( $app['root'], $app['type'], \Disciple_Tools_Users::get_contact_for_user( get_current_user_id() ), false );
                 }
-                $apps[$app['type']] = array_merge( [
-                    'name' => $app['label'],
-                    'type' => 'Web View',
-                    'icon' => $app['meta']['icon'] ?? '/wp-content/themes/disciple-tools-theme/dt-assets/images/link.svg',
-                    'url' => $app_link,
-                    'slug' => $app['type'],
-                    'sort' => $app['sort'] ?? 10,
-                    'is_hidden' => false,
-                ], $apps[$app['type']] ?? [] );
+                if ( !empty( $app_link ) ) {
+                    $apps[$app['type']] = array_merge( [
+                        'name' => $app['label'],
+                        'type' => 'Link',
+                        'creation_type' => 'code',
+                        'icon' => $app['meta']['icon'] ?? '/wp-content/themes/disciple-tools-theme/dt-assets/images/link.svg',
+                        'url' => $app_link,
+                        'slug' => $app['type'],
+                        'sort' => $app['sort'] ?? 10,
+                        'is_hidden' => false,
+                        'open_in_new_tab' => true,
+                        'magic_link_meta' => [
+                            'post_type' => $app['post_type'],
+                            'root' => $app['root'],
+                            'type' => $app['type']
+                        ]
+                    ], $apps[$app['type']] ?? [] );
+                }
             }
         }
 		// Sort the array based on the 'sort' key
@@ -100,7 +109,8 @@ class Apps {
 	 * @return array The apps array for the user.
 	 */
 	public function for_user( $user_id ) {
-		$user_apps = get_user_option( 'dt_home_apps', $user_id );
+
+        $user_apps = get_user_option( 'dt_home_apps', $user_id );
 		if ( ! $user_apps ) {
 			$user_apps = [];
 		}
@@ -122,6 +132,18 @@ class Apps {
                     ]
 				);
 			}
+
+            // If required, source correct user keys for magic link app urls.
+            if ( !empty( $app['magic_link_meta'] ) && isset( $app['magic_link_meta']['post_type' ], $app['magic_link_meta']['root' ], $app['magic_link_meta']['type' ] ) ) {
+                switch ( $app['magic_link_meta']['post_type'] ) {
+                    case 'user':
+                        $apps[ $idx ]['url'] = get_magic_url( $app['magic_link_meta']['root'], $app['magic_link_meta']['type'], $user_id );
+                        break;
+                    case 'contacts':
+                        $apps[ $idx ]['url'] = get_magic_url( $app['magic_link_meta']['root'], $app['magic_link_meta']['type'], \Disciple_Tools_Users::get_contact_for_user( $user_id ) );
+                        break;
+                }
+            }
 		}
         $apps = array_filter( $apps, function ( $app ) {
             return ( $app['is_deleted'] ?? false ) === false;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -371,27 +371,42 @@ function magic_app( $root, $type )
  * @param string $root The root of the magic URL.
  * @param string $type The type of the magic URL.
  * @param int $id The ID of the post to generate the magic URL for.
+ * @param bool $inc_ml_key Flag to indicate if magic link key should be appended to URL.
  *
  * @return string The generated magic URL.
  */
-function get_magic_url( $root, $type, $id ): string
+function get_magic_url( $root, $type, $id, $inc_ml_key = true ): string
 {
     $app = magic_app( $root, $type );
     if ( !$app ) {
         return "";
     }
     if ( $app['post_type'] === 'user' ) {
-
         $app_user_key = get_user_option( $app['meta_key'] );
+
+        // Auto generated new key if required.
+        if ( empty( $app_user_key ) ) {
+            $app_user_key = dt_create_unique_key();
+            update_user_option( $id, $app['meta_key'], $app_user_key );
+        }
         $app_url_base = trailingslashit( trailingslashit( site_url() ) . $app['url_base'] );
-        return $app_url_base . $app_user_key;
+        return $app_url_base . ( $inc_ml_key ? $app_user_key : '' );
     } else {
-        return DT_Magic_URL::get_link_url_for_post(
+        $url = DT_Magic_URL::get_link_url_for_post(
             $app["post_type"],
             $id,
             $app["root"],
             $app["type"]
         );
+
+        // If specified, remove trailing magic-link key from url.
+        if ( !$inc_ml_key ) {
+            $url_base = $app["root"] . '/' . $app["type"] . '/';
+            $url_base_offset = strrpos( $url, $url_base );
+            $url = substr( $url, 0, ( $url_base_offset + strlen( $url_base ) ) );
+        }
+
+        return $url;
     }
 }
 


### PR DESCRIPTION
- Summary:
  - Logic now avoids blank screens.
  - Ensure ML Keys are no longer saved within admin settings and sourced accordingly within the frontend for correct current user.
    - This now ensures users are no longer shown the wrong ML app session.
  
- Outstanding Tasks:
  - Ensure ML Apps can be removed and placed into Available Apps section.
  - Ensure ML Apps work within Web Views; as URL structure has now changed; so some additional refactoring will be required.
    - For now, defaulting to type Link.