### PR TITLE
Change the name of the Disciple Tools app in the Home Screen to Disciple.Tools

### DIFF
--- a/src/Apps/DiscipleTools.php
+++ b/src/Apps/DiscipleTools.php
@@ -7,7 +7,7 @@ class DiscipleTools extends App
     public function config(): array
     {
         return [
-            "name" => "Disciple Tools",
+            "name" => "Disciple.Tools",
             "type" => "Web View",
             'creation_type' => 'code',
             "icon" => "/wp-content/themes/disciple-tools-theme/dt-assets/images/dt-caret.png",


### PR DESCRIPTION
Change the name of the Disciple Tools app in the Home Screen to Disciple.Tools

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206274572403899