### PR TITLE
text domain should match plugin slug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ code that will be used in or with D.T.
 
 D.T is already being used in multiple languages. Please help us make D.T translable by taking full advantage of
 Wordpress’ translatable strings. Any string that will be read by the user must be marked as translatable. Ex:
-`<label class="section-header"><?php esc_html_e( 'Other', 'dt_home' )?></label>`
+`<label class="section-header"><?php esc_html_e( 'Other', 'dt-home' )?></label>`
 
 Make sure you look for these in PHP, HTML and JavaScript code.
 

--- a/dt-home.php
+++ b/dt-home.php
@@ -3,7 +3,7 @@
  * Plugin Name: DT Home
  * Plugin URI: https://github.com/TheCodeZone/dt_home
  * Description: An app home screen for disciple.tools. Part of the DT Toolbox.
- * Text Domain: dt_home
+ * Text Domain: dt-home
  * Domain Path: /languages
  * Version:  1.0.2
  * Author URI: https://github.com/TheCodeZone

--- a/resources/views/auth/login.php
+++ b/resources/views/auth/login.php
@@ -34,13 +34,13 @@ $this->layout( 'layouts/auth' );
                 <?php endif; ?>
 
                 <dt-text name="username"
-                         placeholder="<?php esc_attr_e( 'Username or Email Address', 'dt_home' ); ?>"
+                         placeholder="<?php esc_attr_e( 'Username or Email Address', 'dt-home' ); ?>"
                          value="<?php echo esc_attr( $username ); ?>"
                          required
                          tabindex="1"
                 ></dt-text>
                 <dt-text name="password"
-                         placeholder="<?php esc_attr_e( 'Password', 'dt_home' ); ?>"
+                         placeholder="<?php esc_attr_e( 'Password', 'dt-home' ); ?>"
                          value="<?php echo esc_attr( $password ); ?>"
                          type="password"
                          tabindex="2"
@@ -49,7 +49,7 @@ $this->layout( 'layouts/auth' );
                 <sp-button-group>
                     <sp-button tabindex="3" class="login-sp-button-radius"
                                type="submit">
-                        <span><?php esc_html_e( 'Login', 'dt_home' ) ?></span>
+                        <span><?php esc_html_e( 'Login', 'dt-home' ) ?></span>
 
                     </sp-button>
 

--- a/resources/views/auth/register.php
+++ b/resources/views/auth/register.php
@@ -54,7 +54,7 @@ $this->layout( 'layouts/auth' );
                            tabindex="3"
                            treatment="fill"
                            type="submit">
-                    <span><?php esc_html_e( 'Register', 'dt_home' ) ?></span>
+                    <span><?php esc_html_e( 'Register', 'dt-home' ) ?></span>
                 </sp-button>
             </form>
         </div>
@@ -64,7 +64,7 @@ $this->layout( 'layouts/auth' );
                    variant="secondary"
                    treatment="link"
         >
-            <span><?php esc_html_e( 'Back to Login', 'dt_home' ); ?></span>
+            <span><?php esc_html_e( 'Back to Login', 'dt-home' ); ?></span>
         </sp-button>
     </div>
 </div>

--- a/resources/views/hidden-apps.php
+++ b/resources/views/hidden-apps.php
@@ -25,11 +25,11 @@ $this->layout( 'layouts/plugin' );
     </div>
 
     <b>
-        <?php esc_html_e( 'Name:', 'dt_home' ); ?> <?php echo esc_html( $user->user_nicename ); ?>
+        <?php esc_html_e( 'Name:', 'dt-home' ); ?> <?php echo esc_html( $user->user_nicename ); ?>
     </b>
 
     <a href="<?php echo esc_url( $subpage_url ); ?>">
-        <?php esc_html_e( 'Visit subpage', 'dt_home' ); ?>
+        <?php esc_html_e( 'Visit subpage', 'dt-home' ); ?>
     </a>
 
     <dt-home-footer></dt-home-footer>

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -15,7 +15,7 @@ $this->layout( 'layouts/plugin' );
         <?php
         echo wp_json_encode(
             [
-                'helpText' => __( 'Copy this link and share it with people you are coaching', 'dt_home' ),
+                'helpText' => __( 'Copy this link and share it with people you are coaching', 'dt-home' ),
             ]
         )
         ?>
@@ -39,8 +39,8 @@ $this->layout( 'layouts/plugin' );
 
 <dt-home-footer id="hiddenApps"
                 translations='<?php echo wp_json_encode( [
-                    "hiddenAppsLabel" => __( "Hidden Apps", 'dt_home' ),
-                    "buttonLabel"     => __( "Ok", 'dt_home' )
+                    "hiddenAppsLabel" => __( "Hidden Apps", 'dt-home' ),
+                    "buttonLabel"     => __( "Ok", 'dt-home' )
                 ] ) ?>'
                 hidden-data='<?php echo esc_attr( htmlspecialchars( $data ) ); ?>'
                 app-url-unhide='<?php echo esc_url( $app_url ); ?>'

--- a/resources/views/layouts/plugin.php
+++ b/resources/views/layouts/plugin.php
@@ -8,10 +8,10 @@ $dashboard = '/';
 $menu_items = [];
 
 // Adding default menu items
-$menu_items[] = [ 'label' => __( 'Apps', 'dt_home' ), 'href' => $home ];
-$menu_items[] = [ 'label' => __( 'Training', 'dt_home' ), 'href' => magic_url( 'training' ) ];
+$menu_items[] = [ 'label' => __( 'Apps', 'dt-home' ), 'href' => $home ];
+$menu_items[] = [ 'label' => __( 'Training', 'dt-home' ), 'href' => magic_url( 'training' ) ];
 //if ( get_option( 'dt_home_require_login', true ) ) {
-$menu_items[] = [ 'label' => __( 'Log Out', 'dt_home' ), 'href' => magic_url( 'logout' ) ];
+$menu_items[] = [ 'label' => __( 'Log Out', 'dt-home' ), 'href' => magic_url( 'logout' ) ];
 //}
 
 

--- a/resources/views/layouts/settings.php
+++ b/resources/views/layouts/settings.php
@@ -9,10 +9,10 @@ $nav = apply_filters( namespace_string( 'settings_tabs' ), [] );
 ?>
 
 <hr class="wrap">
-<h1><?php esc_html_e( 'Home Screen', 'dt_home' ) ?></h1>
+<h1><?php esc_html_e( 'Home Screen', 'dt-home' ) ?></h1>
 
 <p class="tagline">
-    <?php esc_html_e( 'Part of the DT Toolbox', 'dt_home' ) ?>
+    <?php esc_html_e( 'Part of the DT Toolbox', 'dt-home' ) ?>
 </p>
 
 <h2 class="nav-tab-wrapper">

--- a/resources/views/settings/app.php
+++ b/resources/views/settings/app.php
@@ -14,24 +14,24 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
             <div class="col-md-12">
                 <span style="float:left;">
                     <a href="admin.php?page=dt_home&tab=app&action=available_app" class="button float-right">
-                        <i class="fa fa-plus"></i><?php esc_html_e( 'Available Apps', 'dt_home' ); ?>
+                        <i class="fa fa-plus"></i><?php esc_html_e( 'Available Apps', 'dt-home' ); ?>
                     </a>
                 </span>
                 &nbsp;&nbsp;&nbsp;
                 <span style="float:right;">
                     <a href="admin.php?page=dt_home&tab=app&action=create" class="button float-right">
-                        <i class="fa fa-plus"></i><?php esc_html_e( 'Add App', 'dt_home' ); ?>
+                        <i class="fa fa-plus"></i><?php esc_html_e( 'Add App', 'dt-home' ); ?>
                     </a>
                 </span>
                 <br><br>
                 <table class="widefat striped" style="border-collapse: collapse; width: 100%;">
                     <thead>
                     <tr>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Name', 'dt_home' ); ?></th>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Type', 'dt_home' ); ?></th>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Icon', 'dt_home' ); ?></th>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Slug', 'dt_home' ); ?></th>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Action', 'dt_home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Name', 'dt-home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Type', 'dt-home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Icon', 'dt-home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Slug', 'dt-home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Action', 'dt-home' ); ?></th>
                     </tr>
                     </thead>
                     <tbody>
@@ -56,7 +56,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                             <td style="border: 1px solid #ddd;">
                                 <?php if ( !empty( $app['icon'] ) ) : ?>
                                     <?php if ( filter_var( $app['icon'], FILTER_VALIDATE_URL ) || strpos( $app['icon'], '/wp-content/' ) === 0 ) : ?>
-                                        <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php esc_attr_e( 'Icon', 'dt_home' ); ?>" style="width: 50px; height: 50px;">
+                                        <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php esc_attr_e( 'Icon', 'dt-home' ); ?>" style="width: 50px; height: 50px;">
                                     <?php elseif ( preg_match( '/^mdi\smdi-/', $app['icon'] ) ) : ?>
                                         <i class="<?php echo esc_attr( $app['icon'] ); ?>" style="font-size: 50px;"></i>
                                     <?php endif; ?>
@@ -64,23 +64,23 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                             </td>
                             <td style="border: 1px solid #ddd;"><?php echo esc_attr( $app['slug'] ); ?></td>
                             <td style="border: 1px solid #ddd;">
-                                <a href="admin.php?page=dt_home&tab=app&action=up/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Up', 'dt_home' ); ?></a>&nbsp;|&nbsp;
+                                <a href="admin.php?page=dt_home&tab=app&action=up/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Up', 'dt-home' ); ?></a>&nbsp;|&nbsp;
                                 <?php if ( $app['is_hidden'] == 1 ) { ?>
-                                    <a href="admin.php?page=dt_home&tab=app&action=unhide/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Unhide', 'dt_home' ); ?></a>&nbsp;|&nbsp;
+                                    <a href="admin.php?page=dt_home&tab=app&action=unhide/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Unhide', 'dt-home' ); ?></a>&nbsp;|&nbsp;
                                 <?php } else { ?>
-                                    <a href="admin.php?page=dt_home&tab=app&action=hide/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Hide', 'dt_home' ); ?></a>&nbsp;|&nbsp;
+                                    <a href="admin.php?page=dt_home&tab=app&action=hide/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Hide', 'dt-home' ); ?></a>&nbsp;|&nbsp;
                                 <?php } ?>
-                                <a href="admin.php?page=dt_home&tab=app&action=edit/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Edit', 'dt_home' ); ?></a>&nbsp;|&nbsp;
-                                <a href="admin.php?page=dt_home&tab=app&action=down/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Down', 'dt_home' ); ?></a>&nbsp;
+                                <a href="admin.php?page=dt_home&tab=app&action=edit/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Edit', 'dt-home' ); ?></a>&nbsp;|&nbsp;
+                                <a href="admin.php?page=dt_home&tab=app&action=down/<?php echo esc_attr( $app['slug'] ); ?>"><?php esc_html_e( 'Down', 'dt-home' ); ?></a>&nbsp;
                                 <?php if ( !isset( $app['creation_type'] ) || ( $app['creation_type'] != 'code' ) ) { ?>
                                     |&nbsp;
                                     <a href="#" onclick="deleteApp('<?php echo esc_attr( $app['slug'] ); ?>')" class="delete-apps">
-                                        <?php esc_html_e( 'Delete', 'dt_home' ); ?>
+                                        <?php esc_html_e( 'Delete', 'dt-home' ); ?>
                                     </a>
                                 <?php } else { ?>
                                     |&nbsp;
                                     <a href="#" onclick="softdelete('<?php echo esc_attr( $app['slug'] ); ?>')" class="delete-apps">
-                                        <?php esc_html_e( 'Delete', 'dt_home' ); ?>
+                                        <?php esc_html_e( 'Delete', 'dt-home' ); ?>
                                     </a>
                                 <?php } ?>
                             </td>
@@ -94,7 +94,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 </div>
 <script>
     function deleteApp(slug) {
-        var confirmation = confirm(<?php echo json_encode( __( 'Are you sure you want to delete this app?', 'dt_home' ) ); ?>);
+        var confirmation = confirm(<?php echo json_encode( __( 'Are you sure you want to delete this app?', 'dt-home' ) ); ?>);
         if (confirmation) {
             // If the user confirms, redirect to the delete URL
             window.location.href = "admin.php?page=dt_home&tab=app&action=delete/" + slug;
@@ -102,7 +102,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
         // If the user cancels, do nothing
     }
     function softdelete(slug) {
-        var confirmation = confirm(<?php echo json_encode( __( 'Are you sure you want to delete this app?', 'dt_home' ) ); ?>);
+        var confirmation = confirm(<?php echo json_encode( __( 'Are you sure you want to delete this app?', 'dt-home' ) ); ?>);
         if (confirmation) {
             // If the user confirms, redirect to the delete URL
             window.location.href = "admin.php?page=dt_home&tab=app&action=softdelete/" + slug;

--- a/resources/views/settings/available-apps.php
+++ b/resources/views/settings/available-apps.php
@@ -14,7 +14,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
             <div class="col-md-12">
                 <span style="float:right;">
                     <a href="admin.php?page=dt_home&tab=app" class="button float-right">
-                        <i class="fa fa-plus"></i><?php esc_html_e( 'Go Back', 'dt_home' ); ?>
+                        <i class="fa fa-plus"></i><?php esc_html_e( 'Go Back', 'dt-home' ); ?>
                     </a>
                 </span>
 
@@ -23,17 +23,17 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                 <table class="widefat striped" style="border-collapse: collapse; width: 100%;">
                     <thead>
                     <tr>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Name', 'dt_home' ); ?></th>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Type', 'dt_home' ); ?></th>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Icon', 'dt_home' ); ?></th>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Slug', 'dt_home' ); ?></th>
-                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Action', 'dt_home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Name', 'dt-home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Type', 'dt-home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Icon', 'dt-home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Slug', 'dt-home' ); ?></th>
+                        <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Action', 'dt-home' ); ?></th>
                     </tr>
                     </thead>
                     <tbody>
                     <?php if ( empty( $data ) ) : ?>
                         <tr>
-                            <td colspan="5" style="text-align: center;border: 1px solid #ddd;"><?php esc_html_e( 'No apps found', 'dt_home' ); ?></td>
+                            <td colspan="5" style="text-align: center;border: 1px solid #ddd;"><?php esc_html_e( 'No apps found', 'dt-home' ); ?></td>
                         </tr>
                     <?php endif; ?>
                     <?php foreach ( $data as $app ) : ?>
@@ -43,7 +43,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                             <td style="border: 1px solid #ddd;">
                                 <?php if ( !empty( $app['icon'] ) ) : ?>
                                     <?php if ( filter_var( $app['icon'], FILTER_VALIDATE_URL ) || strpos( $app['icon'], '/wp-content/' ) === 0 ) : ?>
-                                        <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php esc_attr_e( 'Icon', 'dt_home' ); ?>" style="width: 50px; height: 50px;">
+                                        <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php esc_attr_e( 'Icon', 'dt-home' ); ?>" style="width: 50px; height: 50px;">
                                     <?php elseif ( preg_match( '/^mdi\smdi-/', $app['icon'] ) ) : ?>
                                         <i class="<?php echo esc_attr( $app['icon'] ); ?>" style="font-size: 50px;"></i>
                                     <?php endif; ?>
@@ -55,7 +55,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                                 <?php if ( isset( $app['creation_type'] ) && $app['creation_type'] == 'code' ) : ?>
                                     &nbsp;
                                     <a href="#" onclick="restore_app('<?php echo esc_attr( $app['slug'] ); ?>')" class="delete-apps">
-                                        <?php esc_html_e( 'Restore', 'dt_home' ); ?>
+                                        <?php esc_html_e( 'Restore', 'dt-home' ); ?>
                                     </a>
                                 <?php endif; ?>
                             </td>
@@ -70,7 +70,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 </div>
 <script>
     function restore_app(slug) {
-        var confirmation = confirm(<?php echo json_encode( __( 'Are you sure you want to restore this app?', 'dt_home' ) ); ?>);
+        var confirmation = confirm(<?php echo json_encode( __( 'Are you sure you want to restore this app?', 'dt-home' ) ); ?>);
         if (confirmation) {
             // If the user confirms, redirect to the delete URL
             window.location.href = "admin.php?page=dt_home&tab=app&action=restore_app/" + slug;

--- a/resources/views/settings/create.php
+++ b/resources/views/settings/create.php
@@ -21,41 +21,41 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
     <table class="widefat striped" id="ml_email_main_col_config">
     <thead>
     <tr>
-        <th><?php esc_html_e('Apps', 'dt_home') ?></th>
+        <th><?php esc_html_e('Apps', 'dt-home') ?></th>
         <th></th>
         <th></th>
     </tr>
     </thead>
     <tbody>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Name', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Name', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Enter the name of the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Enter the name of the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="2">
-            <input style="min-width: 100%;" class="form-control" type="text" name="name" id="name" pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt_home'); ?>" required/>
+            <input style="min-width: 100%;" class="form-control" type="text" name="name" id="name" pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt-home'); ?>" required/>
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Type', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Type', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Select the type of the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Select the type of the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="2">
             <select style="min-width: 100%;" name="type" id="type" required onchange="toggleURLField()">
-                <option value=""><?php esc_html_e('Please select', 'dt_home') ?></option>
-                <option value="Web View"><?php esc_html_e('Web View', 'dt_home') ?></option>
-                <option value="Link"><?php esc_html_e('Link', 'dt_home') ?></option>
+                <option value=""><?php esc_html_e('Please select', 'dt-home') ?></option>
+                <option value="Web View"><?php esc_html_e('Web View', 'dt-home') ?></option>
+                <option value="Link"><?php esc_html_e('Link', 'dt-home') ?></option>
             </select>
             <input name="creation_type" id="creation_type" type="hidden" value="custom" />
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Open link in new tab', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Open link in new tab', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Check this box to open the link in a new tab.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Check this box to open the link in a new tab.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="2">
@@ -63,23 +63,23 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Icon (File Upload)', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Icon (File Upload)', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Upload an icon for the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Upload an icon for the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td style="vertical-align: middle;"><input style="min-width: 100%;" type="text" id="app_icon"  name="icon" pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt_home'); ?>" required/></td>
+        <td style="vertical-align: middle;"><input style="min-width: 100%;" type="text" id="app_icon"  name="icon" pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt-home'); ?>" required/></td>
         <td style="vertical-align: middle;"><span id="app_icon_show"></span></td>
         <td style="vertical-align: middle;">
             <a href="#" class="button change-icon-button">
-                <?php esc_html_e('Change Icon', 'dt_home'); ?>
+                <?php esc_html_e('Change Icon', 'dt-home'); ?>
             </a>
         </td>
     </tr>
     <tr id="urlFieldRow">
-        <td style="vertical-align: middle;"><?php esc_html_e('URL', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('URL', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Enter the URL for the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Enter the URL for the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="2">
@@ -87,19 +87,19 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Slug', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Slug', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Enter a slug for the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Enter a slug for the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="2">
-            <input style="min-width: 100%;" type="text" name="slug" id="slug" pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt_home'); ?>" required/>
+            <input style="min-width: 100%;" type="text" name="slug" id="slug" pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt-home'); ?>" required/>
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Is Hidden', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Is Hidden', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Check this box to hide the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Check this box to hide the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="2">
@@ -113,20 +113,20 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
     <span id="ml_email_main_col_update_msg" style="font-weight: bold; color: red;"></span>
     <span style="float:right;">
         <a href="admin.php?page=dt_home&tab=app"
-           class="button float-right"><?php esc_html_e('Cancel', 'dt_home') ?></a>
+           class="button float-right"><?php esc_html_e('Cancel', 'dt-home') ?></a>
         <button type="submit" id="ml_email_main_col_update_but"
-                class="button float-right"><?php esc_html_e('Submit', 'dt_home') ?></button>
+                class="button float-right"><?php esc_html_e('Submit', 'dt-home') ?></button>
     </span>
 </form>
 
 <div id="popup" class="popup">
-    <input type="text" id="searchInput" onkeyup="filterIcons()" placeholder="<?php esc_attr_e('Search for icons...', 'dt_home'); ?>"
+    <input type="text" id="searchInput" onkeyup="filterIcons()" placeholder="<?php esc_attr_e('Search for icons...', 'dt-home'); ?>"
            style="width: 100%; padding: 10px; margin-bottom: 10px;">
     <div class="svg-container" id="svgContainer">
         <!-- SVG icons will be dynamically inserted here -->
     </div>
     <br>
-    <button class="btn btn-secondary" onclick="hidePopup()"><?php esc_html_e('Close', 'dt_home') ?></button>
+    <button class="btn btn-secondary" onclick="hidePopup()"><?php esc_html_e('Close', 'dt-home') ?></button>
 </div>
 
 <?php $this->start('right') ?>

--- a/resources/views/settings/edit.php
+++ b/resources/views/settings/edit.php
@@ -20,7 +20,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
     <table class="widefat striped" id="ml_email_main_col_config">
     <thead>
     <tr>
-        <th><?php esc_html_e('Apps', 'dt_home') ?></th>
+        <th><?php esc_html_e('Apps', 'dt-home') ?></th>
         <th></th>
         <th></th>
         <th></th>
@@ -28,42 +28,42 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
     </thead>
    <tbody>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Name', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Name', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Enter the name of the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Enter the name of the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="3">
             <input style="min-width: 100%;" type="text" name="name" id="name" class="form-control"
-                   pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt_home'); ?>"
+                   pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt-home'); ?>"
                    value="<?php echo esc_attr($existing_data['name']); ?>" required>
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Type', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Type', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Select the type of the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Select the type of the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="3">
             <select style="min-width: 100%;" id="type" name="type" required onchange="toggleURLField()">
                 <option value="" <?php echo empty($existing_data['type']) ? 'selected' : ''; ?>>
-                    <?php esc_html_e('Please select', 'dt_home') ?>
+                    <?php esc_html_e('Please select', 'dt-home') ?>
                 </option>
                 <option value="Web View" <?php echo ($existing_data['type'] === 'Web View') ? 'selected' : ''; ?>>
-                    <?php esc_html_e('Web View', 'dt_home') ?>
+                    <?php esc_html_e('Web View', 'dt-home') ?>
                 </option>
                 <option value="Link" <?php echo ($existing_data['type'] === 'Link') ? 'selected' : ''; ?>>
-                    <?php esc_html_e('Link', 'dt_home') ?>
+                    <?php esc_html_e('Link', 'dt-home') ?>
                 </option>
             </select>
             <input name="creation_type" id="creation_type" type="hidden" value="<?php echo esc_attr( $existing_data['creation_type'] ?? '' ) ?>" />
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Open link in new tab', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Open link in new tab', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Check this box to open the link in a new tab.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Check this box to open the link in a new tab.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="2">
@@ -72,15 +72,15 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Icon (File Upload)', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Icon (File Upload)', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Upload an icon for the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Upload an icon for the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td style="vertical-align: middle;">
             <?php if (!empty($existing_data['icon'])) : ?>
                 <?php if (filter_var($existing_data['icon'], FILTER_VALIDATE_URL) || strpos($existing_data['icon'], '/wp-content/') === 0) : ?>
-                    <img src="<?php echo esc_url($existing_data['icon']); ?>" alt="<?php esc_attr_e('Icon', 'dt_home'); ?>"
+                    <img src="<?php echo esc_url($existing_data['icon']); ?>" alt="<?php esc_attr_e('Icon', 'dt-home'); ?>"
                          style="width: 50px; height: 50px;">
                 <?php elseif (preg_match('/^mdi\smdi-/', $existing_data['icon'])) : ?>
                     <i class="<?php echo esc_attr($existing_data['icon']); ?>" style="font-size: 50px;"></i>
@@ -89,22 +89,22 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
         </td>
         <td style="vertical-align: middle;">
             <input style="min-width: 100%;" type="text" id="app_icon" name="icon"
-                   pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt_home'); ?>" required
+                   pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt-home'); ?>" required
                    value="<?php if (filter_var($existing_data['icon'], FILTER_VALIDATE_URL) || strpos($existing_data['icon'], '/wp-content/') === 0) : echo esc_url(isset($existing_data['icon']) ? $existing_data['icon'] : ''); elseif (preg_match('/^mdi\smdi-/', $existing_data['icon'])) : echo esc_attr($existing_data['icon']); endif; ?>"/>
         </td>
         <td style="vertical-align: middle;"><span id="app_icon_show"></span></td>
         <td style="vertical-align: middle;">
             <a href="#" class="button change-icon-button">
-                <?php esc_html_e('Change Icon', 'dt_home'); ?>
+                <?php esc_html_e('Change Icon', 'dt-home'); ?>
             </a>
         </td>
     </tr>
 
     <?php if ($existing_data['type'] === 'Web View' || $existing_data['type'] === 'Link') { ?>
         <tr>
-            <td style="vertical-align: middle;"><?php esc_html_e('URL', 'dt_home') ?>
+            <td style="vertical-align: middle;"><?php esc_html_e('URL', 'dt-home') ?>
                 <span class="tooltip">[?]
-                    <span class="tooltiptext"><?php esc_html_e('Enter the URL for the app.', 'dt_home') ?></span>
+                    <span class="tooltiptext"><?php esc_html_e('Enter the URL for the app.', 'dt-home') ?></span>
                 </span>
             </td>
             <td colspan="3">
@@ -115,9 +115,9 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
     <?php } ?>
 
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Slug', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Slug', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Enter a slug for the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Enter a slug for the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="2">
@@ -127,9 +127,9 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
         </td>
     </tr>
     <tr>
-        <td style="vertical-align: middle;"><?php esc_html_e('Is Hidden', 'dt_home') ?>
+        <td style="vertical-align: middle;"><?php esc_html_e('Is Hidden', 'dt-home') ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e('Check this box to hide the app.', 'dt_home') ?></span>
+                <span class="tooltiptext"><?php esc_html_e('Check this box to hide the app.', 'dt-home') ?></span>
             </span>
         </td>
         <td colspan="3">
@@ -143,9 +143,9 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
     <br>
     <span style="float:right;">
         <a href="admin.php?page=dt_home&tab=app"
-           class="button float-right"><?php esc_html_e('Cancel', 'dt_home') ?></a>
+           class="button float-right"><?php esc_html_e('Cancel', 'dt-home') ?></a>
         <button type="submit" name="submit" id="submit"
-                class="button float-right"><?php esc_html_e('Update', 'dt_home') ?></button>
+                class="button float-right"><?php esc_html_e('Update', 'dt-home') ?></button>
     </span>
 </form>
 

--- a/resources/views/settings/general.php
+++ b/resources/views/settings/general.php
@@ -21,7 +21,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 					<input type="checkbox" id="dt_home_require_login"
 							name="dt_home_require_login" <?php checked( $dt_home_require_login ); ?>
 					>
-					<?php esc_html_e( 'Require users to login to access the home screen magic link?', 'dt_home' ); ?>
+					<?php esc_html_e( 'Require users to login to access the home screen magic link?', 'dt-home' ); ?>
 				</label>
 			</td>
 
@@ -32,7 +32,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 					<input type="checkbox" id="dt_home_reset_apps"
 							name="dt_home_reset_apps" <?php checked( $dt_home_reset_apps ); ?>
 					>
-					<?php esc_html_e( 'Allow users to reset their apps?', 'dt_home' ); ?>
+					<?php esc_html_e( 'Allow users to reset their apps?', 'dt-home' ); ?>
 				</label>
 			</td>
 		</tr>
@@ -52,7 +52,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 		<tr>
 			<td>
 				<button type="submit" id="ml_email_main_col_update_but" class="button float-right">
-					<?php esc_html_e( 'Update', 'dt_home' ); ?>
+					<?php esc_html_e( 'Update', 'dt-home' ); ?>
 				</button>
 			</td>
 		</tr>

--- a/resources/views/settings/training.php
+++ b/resources/views/settings/training.php
@@ -20,7 +20,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
             <div class="col-md-12">
                 <span style="float:right;">
                     <a href="admin.php?page=dt_home&tab=training&action=create" class="button float-right">
-                        <i class="fa fa-plus"></i> <?php esc_html_e( 'Add Training', 'dt_home' ); ?>
+                        <i class="fa fa-plus"></i> <?php esc_html_e( 'Add Training', 'dt-home' ); ?>
                     </a>
                 </span>
 
@@ -29,10 +29,10 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                 <table class="widefat striped" style="border-collapse: collapse; width: 110%;">
                     <thead>
                         <tr>
-                            <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Name', 'dt_home' ); ?></th>
-                            <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Embed Video', 'dt_home' ); ?></th>
-                            <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Anchor', 'dt_home' ); ?></th>
-                            <th style="border: 1px solid #ddd; min-width: 100%;"><?php esc_html_e( 'Action', 'dt_home' ); ?></th>
+                            <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Name', 'dt-home' ); ?></th>
+                            <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Embed Video', 'dt-home' ); ?></th>
+                            <th style="border: 1px solid #ddd;"><?php esc_html_e( 'Anchor', 'dt-home' ); ?></th>
+                            <th style="border: 1px solid #ddd; min-width: 100%;"><?php esc_html_e( 'Action', 'dt-home' ); ?></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -42,10 +42,10 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                                 <td style="border: 1px solid #ddd;"><?php echo stripslashes( $training['embed_video'] ); //phpcs:ignore ?></td>
                                 <td style="border: 1px solid #ddd;"><?php echo esc_html( $training['anchor'] ); ?></td>
                                 <td style="border: 1px solid #ddd;">
-                                    <a href="admin.php?page=dt_home&tab=training&action=up/<?php echo esc_attr( $training['id'] ); ?>"><?php esc_html_e( 'Up', 'dt_home' ); ?></a>&nbsp;|&nbsp;
-                                    <a href="admin.php?page=dt_home&tab=training&action=edit/<?php echo esc_attr( $training['id'] ); ?>"><?php esc_html_e( 'Edit', 'dt_home' ); ?></a>&nbsp;|&nbsp;
-                                    <a href="#" onclick="confirmDelete(<?php echo esc_attr( $training['id'] ); ?>)"><?php esc_html_e( 'Delete', 'dt_home' ); ?></a>&nbsp;|&nbsp;
-                                    <a href="admin.php?page=dt_home&tab=training&action=down/<?php echo esc_attr( $training['id'] ); ?>"><?php esc_html_e( 'Down', 'dt_home' ); ?></a>
+                                    <a href="admin.php?page=dt_home&tab=training&action=up/<?php echo esc_attr( $training['id'] ); ?>"><?php esc_html_e( 'Up', 'dt-home' ); ?></a>&nbsp;|&nbsp;
+                                    <a href="admin.php?page=dt_home&tab=training&action=edit/<?php echo esc_attr( $training['id'] ); ?>"><?php esc_html_e( 'Edit', 'dt-home' ); ?></a>&nbsp;|&nbsp;
+                                    <a href="#" onclick="confirmDelete(<?php echo esc_attr( $training['id'] ); ?>)"><?php esc_html_e( 'Delete', 'dt-home' ); ?></a>&nbsp;|&nbsp;
+                                    <a href="admin.php?page=dt_home&tab=training&action=down/<?php echo esc_attr( $training['id'] ); ?>"><?php esc_html_e( 'Down', 'dt-home' ); ?></a>
                                 </td>
                             </tr>
                         <?php endforeach; ?>
@@ -58,7 +58,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 </div>
 <script>
     function confirmDelete(trainingId) {
-        var confirmation = confirm(<?php echo json_encode( __( 'Are you sure you want to delete this entry?', 'dt_home' ) ); ?>);
+        var confirmation = confirm(<?php echo json_encode( __( 'Are you sure you want to delete this entry?', 'dt-home' ) ); ?>);
         if (confirmation) {
             // If the user confirms, redirect to the delete URL
             window.location.href = "admin.php?page=dt_home&tab=training&action=delete/" + trainingId;

--- a/resources/views/settings/training/create.php
+++ b/resources/views/settings/training/create.php
@@ -7,7 +7,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
     <table class="widefat striped" id="ml_email_main_col_config">
         <thead>
         <tr>
-            <th><?php esc_html_e( 'Training Videos', 'dt_home' ) ?></th>
+            <th><?php esc_html_e( 'Training Videos', 'dt-home' ) ?></th>
             <th></th>
             <th></th>
         </tr>
@@ -15,44 +15,44 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
       <tbody>
     <tr>
         <td style="vertical-align: middle;">
-            <?php esc_html_e( 'Name', 'dt_home' ) ?>
+            <?php esc_html_e( 'Name', 'dt-home' ) ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e( 'Enter the name of the training video.', 'dt_home' ) ?></span>
+                <span class="tooltiptext"><?php esc_html_e( 'Enter the name of the training video.', 'dt-home' ) ?></span>
             </span>
         </td>
         <td colspan="2">
-            <input style="min-width: 100%;" class="form-control" type="text" name="name" id="name" pattern=".*\S+.*" title="<?php esc_attr_e( 'The name cannot be empty or just whitespace.', 'dt_home' ); ?>" required/>
+            <input style="min-width: 100%;" class="form-control" type="text" name="name" id="name" pattern=".*\S+.*" title="<?php esc_attr_e( 'The name cannot be empty or just whitespace.', 'dt-home' ); ?>" required/>
         </td>
     </tr>
     <tr>
         <td style="vertical-align: middle;">
-            <?php esc_html_e( 'Embed Video', 'dt_home' ) ?>
+            <?php esc_html_e( 'Embed Video', 'dt-home' ) ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e( 'Paste the embed code for the video.', 'dt_home' ) ?></span>
+                <span class="tooltiptext"><?php esc_html_e( 'Paste the embed code for the video.', 'dt-home' ) ?></span>
             </span>
         </td>
         <td colspan="2">
             <textarea style="min-width: 100%;" class="form-control" name="embed_video" id="embed_video"
-                      oninput="this.setCustomValidity(this.value.trim() === '' ? '<?php esc_attr_e( 'The embed Video cannot be empty or just whitespace.', 'dt_home' ); ?>' : '')" required></textarea>
+                      oninput="this.setCustomValidity(this.value.trim() === '' ? '<?php esc_attr_e( 'The embed Video cannot be empty or just whitespace.', 'dt-home' ); ?>' : '')" required></textarea>
         </td>
     </tr>
     <tr>
         <td style="vertical-align: middle;">
-            <?php esc_html_e( 'Anchor', 'dt_home' ) ?>
+            <?php esc_html_e( 'Anchor', 'dt-home' ) ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e( 'Specify the anchor text for the video.', 'dt_home' ) ?></span>
+                <span class="tooltiptext"><?php esc_html_e( 'Specify the anchor text for the video.', 'dt-home' ) ?></span>
             </span>
         </td>
         <td colspan="2">
             <input style="min-width: 100%;" class="form-control" type="text" name="anchor" id="anchor"
-                   pattern=".*\S+.*" title="<?php esc_attr_e( 'The anchor text cannot be empty or just whitespace.', 'dt_home' ); ?>" required/>
+                   pattern=".*\S+.*" title="<?php esc_attr_e( 'The anchor text cannot be empty or just whitespace.', 'dt-home' ); ?>" required/>
         </td>
     </tr>
     <tr>
         <td style="vertical-align: middle;">
-            <?php esc_html_e( 'Sort', 'dt_home' ) ?>
+            <?php esc_html_e( 'Sort', 'dt-home' ) ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e( 'Set the sort order for the video.', 'dt_home' ) ?></span>
+                <span class="tooltiptext"><?php esc_html_e( 'Set the sort order for the video.', 'dt-home' ) ?></span>
             </span>
         </td>
         <td colspan="2">
@@ -66,9 +66,9 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
     <span id="ml_email_main_col_update_msg" style="font-weight: bold; color: red;"></span>
     <span style="float:right;">
         <a href="admin.php?page=dt_home&tab=training"
-           class="button float-right"><?php esc_html_e( 'Cancel', 'dt_home' ) ?></a>
+           class="button float-right"><?php esc_html_e( 'Cancel', 'dt-home' ) ?></a>
         <button type="submit" id="ml_email_main_col_update_but"
-                class="button float-right"><?php esc_html_e( 'Submit', 'dt_home' ) ?></button>
+                class="button float-right"><?php esc_html_e( 'Submit', 'dt-home' ) ?></button>
     </span>
 </form>
 

--- a/resources/views/settings/training/edit.php
+++ b/resources/views/settings/training/edit.php
@@ -15,7 +15,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
     <table class="widefat striped" id="ml_email_main_col_config">
     <thead>
     <tr>
-        <th><?php esc_html_e( 'Training Videos', 'dt_home' ) ?></th>
+        <th><?php esc_html_e( 'Training Videos', 'dt-home' ) ?></th>
         <th></th>
         <th></th>
         <th></th>
@@ -24,47 +24,47 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
     <tbody>
     <tr>
       <td style="vertical-align: middle;">
-            <?php esc_html_e( 'Name', 'dt_home' ) ?>
+            <?php esc_html_e( 'Name', 'dt-home' ) ?>
             <span class="tooltip">[?]
-                <span class="tooltiptext"><?php esc_html_e( 'Enter the name of the training video.', 'dt_home' ) ?></span>
+                <span class="tooltiptext"><?php esc_html_e( 'Enter the name of the training video.', 'dt-home' ) ?></span>
             </span>
         </td>
         <td colspan="3">
             <input style="min-width: 100%;" type="text" name="name" id="name" class="form-control"
-                   value="<?php echo esc_attr( $existing_data['name'] ); ?>" pattern=".*\S+.*" title="<?php esc_attr_e( 'The name cannot be empty or just whitespace.', 'dt_home' ); ?>" required>
+                   value="<?php echo esc_attr( $existing_data['name'] ); ?>" pattern=".*\S+.*" title="<?php esc_attr_e( 'The name cannot be empty or just whitespace.', 'dt-home' ); ?>" required>
         </td>
     </tr>
     <tr>
     <td style="vertical-align: middle;">
-        <?php esc_html_e( 'Embed Video', 'dt_home' ) ?>
+        <?php esc_html_e( 'Embed Video', 'dt-home' ) ?>
         <span class="tooltip">[?]
-            <span class="tooltiptext"><?php esc_html_e( 'Paste the embed code for the video.', 'dt_home' ) ?></span>
+            <span class="tooltiptext"><?php esc_html_e( 'Paste the embed code for the video.', 'dt-home' ) ?></span>
         </span>
     </td>
     <td colspan="3">
         <textarea style="min-width: 100%;" class="form-control" name="embed_video" id="embed_video"
-                  oninput="this.setCustomValidity(this.value.trim() === '' ? '<?php esc_attr_e( 'The video embed cannot be empty or just whitespace.', 'dt_home' ); ?>' : '')"
+                  oninput="this.setCustomValidity(this.value.trim() === '' ? '<?php esc_attr_e( 'The video embed cannot be empty or just whitespace.', 'dt-home' ); ?>' : '')"
                   required><?php echo stripslashes( $existing_data['embed_video'] ); //phpcs:ignore ?>
         </textarea>
     </td>
 </tr>
 <tr>
     <td style="vertical-align: middle;">
-        <?php esc_html_e( 'Anchor', 'dt_home' ) ?>
+        <?php esc_html_e( 'Anchor', 'dt-home' ) ?>
         <span class="tooltip">[?]
-            <span class="tooltiptext"><?php esc_html_e( 'Specify the anchor text for the video.', 'dt_home' ) ?> </span>
+            <span class="tooltiptext"><?php esc_html_e( 'Specify the anchor text for the video.', 'dt-home' ) ?> </span>
         </span>
     </td>
     <td colspan="3">
         <input style="min-width: 100%;" class="form-control" type="text" name="anchor" id="anchor"
-               value="<?php echo esc_attr( $existing_data['anchor'] ); ?>" pattern=".*\S+.*" title="<?php esc_attr_e( 'The name cannot be empty or just whitespace.', 'dt_home' ); ?>" required/>
+               value="<?php echo esc_attr( $existing_data['anchor'] ); ?>" pattern=".*\S+.*" title="<?php esc_attr_e( 'The name cannot be empty or just whitespace.', 'dt-home' ); ?>" required/>
     </td>
 </tr>
 <tr>
     <td style="vertical-align: middle;">
-          <?php esc_html_e( 'Sort', 'dt_home' ) ?>
+          <?php esc_html_e( 'Sort', 'dt-home' ) ?>
         <span class="tooltip">[?]
-            <span class="tooltiptext"> <?php esc_html_e( 'Set the sort order for the video.', 'dt_home' ) ?></span>
+            <span class="tooltiptext"> <?php esc_html_e( 'Set the sort order for the video.', 'dt-home' ) ?></span>
         </span>
     </td>
     <td colspan="3">
@@ -79,9 +79,9 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
     <span style="float:right;">
         <input type="hidden" name="edit_id" value="<?php echo esc_attr( $existing_data['id'] ); ?>">
         <a href="admin.php?page=dt_home&tab=training"
-           class="button float-right"><?php esc_html_e( 'Cancel', 'dt_home' ) ?></a>
+           class="button float-right"><?php esc_html_e( 'Cancel', 'dt-home' ) ?></a>
         <button type="submit" name="submit" id="submit"
-                class="button float-right"><?php esc_html_e( 'Update', 'dt_home' ) ?></button>
+                class="button float-right"><?php esc_html_e( 'Update', 'dt-home' ) ?></button>
     </span>
 </form>
 

--- a/resources/views/training.php
+++ b/resources/views/training.php
@@ -5,7 +5,7 @@ $this->layout( 'layouts/plugin' );
  * @var string $data
  */
 ?>
-<h1 class="training"> <?php esc_html_e( 'Training', 'dt_home' ); ?></h1>
+<h1 class="training"> <?php esc_html_e( 'Training', 'dt-home' ); ?></h1>
 <dt-tile>
     <dt-home-video-list training-data='<?php echo htmlspecialchars( $data ); // phpcs:ignore ?>'></dt-home-video-list>
 </dt-tile>

--- a/src/Controllers/Admin/AppSettingsController.php
+++ b/src/Controllers/Admin/AppSettingsController.php
@@ -443,7 +443,7 @@ class AppSettingsController {
         $page_title = "Home Settings";
 
         if ( ! $existing_data ) {
-            return response( __( "App not found", "dt_home" ), 404 );
+            return response( __( 'App not found', 'dt-home' ), 404 );
         }
 
         // Load the edit form view and pass the existing data

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -72,7 +72,7 @@ class LoginController {
 		wp_set_auth_cookie( $user->ID );
 
 		if ( ! $user ) {
-			return $this->show_error( __( 'An unexpected error has occurred.', 'dt_home' ) );
+			return $this->show_error( __( 'An unexpected error has occurred.', 'dt-home' ) );
 		}
 
 		wp_set_current_user( $user->ID );

--- a/src/Controllers/MagicLink/AppController.php
+++ b/src/Controllers/MagicLink/AppController.php
@@ -37,7 +37,7 @@ class AppController
         $app  = $apps->find_for_user( $user_id, $slug );
 
         if ( ! $app ) {
-            return response( __( 'Not Found', 'dt_home' ), 404 );
+            return response( __( 'Not Found', 'dt-home' ), 404 );
         }
 
         // Check if there is a custom action to render the app
@@ -67,7 +67,7 @@ class AppController
         $url = apply_filters( 'dt_home_webview_url', ( $app['url'] ?? '' ), $app );
         if ( ! $url ) {
             // No URL found 404
-            return response( __( 'Not Found', 'dt_home' ), 404 );
+            return response( __( 'Not Found', 'dt-home' ), 404 );
         }
 
         return template( 'web-view', compact( 'app', 'url' ) );

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -63,11 +63,11 @@ class RegisterController {
         ];
 
 		if ( ! $username || ! $password || ! $email ) {
-			return $this->show_error( __( 'Please fill out all fields.', 'dt_home' ), $old_input );
+			return $this->show_error( __( 'Please fill out all fields.', 'dt-home' ), $old_input );
 		}
 
 		if ( $confirm_password !== $password ) {
-            return $this->show_error( __( 'Passwords do not match.', 'dt_home' ), $old_input );
+            return $this->show_error( __( 'Passwords do not match.', 'dt-home' ), $old_input );
 		}
 
 		$user = wp_create_user( $username, $password, $email );
@@ -82,7 +82,7 @@ class RegisterController {
 		wp_set_auth_cookie( $user_obj->ID );
 
 		if ( ! $user ) {
-            return $this->show_error( __( 'An unexpected error has occurred.', 'dt_home' ), $old_input );
+            return $this->show_error( __( 'An unexpected error has occurred.', 'dt-home' ), $old_input );
 		}
 
 		return redirect( route_url() );

--- a/src/Services/Settings.php
+++ b/src/Services/Settings.php
@@ -35,8 +35,8 @@ class Settings {
      */
     public function register_menu(): void {
         $menu = add_submenu_page( 'dt_extensions',
-            __( 'Home Screen', 'dt_home' ),
-            __( 'Home Screen', 'dt_home' ),
+            __( 'Home Screen', 'dt-home' ),
+            __( 'Home Screen', 'dt-home' ),
             'manage_dt',
             'dt_home',
             [ $this, 'route' ]
@@ -44,15 +44,15 @@ class Settings {
 
         add_filter(namespace_string( 'settings_tabs' ), function ( $menu ) {
             $menu[] = [
-                'label' => __( 'General', 'dt_home' ),
+                'label' => __( 'General', 'dt-home' ),
                 'tab' => 'general'
             ];
             $menu[] = [
-                'label' => __( 'Apps', 'dt_home' ),
+                'label' => __( 'Apps', 'dt-home' ),
                 'tab' => 'app'
             ];
             $menu[] = [
-                'label' => __( 'Training Videos', 'dt_home' ),
+                'label' => __( 'Training Videos', 'dt-home' ),
                 'tab' => 'training'
             ];
 


### PR DESCRIPTION
We messed this up on the theme, but the text domain [should be the same as the plugin slug ](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/).

This will fix the plugin not installing on the extensions page.