### PR TITLE
Ability to customize the color of the +button for adding new apps

### DIFF
--- a/config/options.php
+++ b/config/options.php
@@ -10,6 +10,7 @@ $config->merge( [
         'defaults' => [
             'require_login' => true,
             'reset_apps'    => false,
+            'button_color'  => '#3fab3f',
             'apps'          => [],
             'trainings'     => [],
         ],

--- a/resources/css/admin.css
+++ b/resources/css/admin.css
@@ -106,3 +106,10 @@ body {
         margin-left: -5px; /* Center the arrow */
     }
 }
+/* Color Picker */
+    .color-picker{
+        width: 30px;
+        height: 30px;
+        border: none !important;
+        cursor: pointer;
+    }

--- a/resources/css/admin.css
+++ b/resources/css/admin.css
@@ -108,8 +108,8 @@ body {
 }
 /* Color Picker */
     .color-picker{
-        width: 30px;
-        height: 30px;
+        width: 25px;
+        height: 25px;
         border: none !important;
         cursor: pointer;
     }

--- a/resources/js/components/home-footer.js
+++ b/resources/js/components/home-footer.js
@@ -13,6 +13,7 @@ class HomeFooter extends LitElement {
     static properties = {
         appUrl: { type: String },
         resetApps: { type: Boolean },
+        buttonColor: { type: String },
     }
 
     @property({ type: Object })
@@ -56,8 +57,9 @@ class HomeFooter extends LitElement {
         --spectrum-button-top-to-text-medium: 0px;
         --spectrum-workflow-icon-size-100: 26px;
         --spectrum-button-edge-to-text: 0px;
-        --system-spectrum-button-accent-background-color-hover: #3fab3f;
-        --system-spectrum-button-accent-background-color-down: #3fab3f;
+        --system-spectrum-button-accent-background-color-hover: var(--button-color);
+        --system-spectrum-button-accent-background-color-down: var(--button-color);
+        --system-spectrum-button-accent-background-color-default: var(--button-color);
         --spectrum-focus-indicator-color: transparent;
         border-radius: 50%;
       }
@@ -221,12 +223,14 @@ class HomeFooter extends LitElement {
     connectedCallback() {
         super.connectedCallback()
         this.loadAppData()
+        this.style.setProperty('--button-color', this.buttonColor)
     }
 
     loadAppData() {
         const jsonData = this.getAttribute('hidden-data')
         this.appUrl = this.getAttribute('app-url-unhide')
         this.resetApps = this.getAttribute('reset-apps') === '1'
+        this.buttonColor = this.getAttribute('button-color')
         if (jsonData) {
             this.appData = JSON.parse(jsonData)
         }

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -6,6 +6,7 @@
  * @var string $subpage_url
  * @var WP_User $user
  * @var string $reset_apps
+ * @var string $button_color
  */
 $this->layout( 'layouts/plugin' );
 ?>
@@ -44,7 +45,8 @@ $this->layout( 'layouts/plugin' );
                 ] ) ?>'
                 hidden-data='<?php echo esc_attr( htmlspecialchars( $data ) ); ?>'
                 app-url-unhide='<?php echo esc_url( $app_url ); ?>'
-                reset-apps='<?php echo esc_attr( $reset_apps ); ?>'>
+                reset-apps='<?php echo esc_attr( $reset_apps ); ?>'
+                button-color='<?php echo esc_attr( $button_color ); ?>'>
 </dt-home-footer>
 
 <?php $this->stop(); ?>

--- a/resources/views/settings/general.php
+++ b/resources/views/settings/general.php
@@ -7,6 +7,7 @@
  * @var string $page_title
  * @var string $dt_home_require_login
  * @var string $dt_home_reset_apps
+ * @var string $dt_home_button_color
  */
 $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 ?>
@@ -36,6 +37,16 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 				</label>
 			</td>
 		</tr>
+        <tr>
+            <td>
+            <label for="dt_home_button_color">
+                <input type="color" id="dt_home_button_color" class="color-picker"
+                       name="dt_home_button_color" value="<?php echo esc_attr( $dt_home_button_color ); ?>"
+                >
+                <?php esc_html_e( 'Customize Add Button Color?', 'dt-home' ); ?>
+            </label>
+            </td>
+        </tr>
 		<!--For giving some space between the field and the button.-->
 		<tr>
 			<td></td>

--- a/src/Controllers/Admin/GeneralSettingsController.php
+++ b/src/Controllers/Admin/GeneralSettingsController.php
@@ -4,6 +4,7 @@ namespace DT\Home\Controllers\Admin;
 
 use DT\Home\GuzzleHttp\Psr7\ServerRequest as Request;
 use DT\Home\Psr\Http\Message\ResponseInterface;
+use function DT\Home\config;
 use function DT\Home\extract_request_input;
 use function DT\Home\get_plugin_option;
 use function DT\Home\redirect;
@@ -38,7 +39,7 @@ class GeneralSettingsController {
 		$input        = extract_request_input( $request );
 		$require_user = $input['dt_home_require_login'] ?? 'off';
 		$reset_apps   = $input['dt_home_reset_apps'] ?? 'off';
-        $button_color = $input['dt_home_button_color'] ?? '#3fab3f';
+        $button_color = $input['dt_home_button_color'] ?? config( 'options.defaults.button_color' );
 
 		set_plugin_option( 'require_login', $require_user === 'on' );
 		set_plugin_option( 'reset_apps', $reset_apps === 'on' );

--- a/src/Controllers/Admin/GeneralSettingsController.php
+++ b/src/Controllers/Admin/GeneralSettingsController.php
@@ -22,7 +22,7 @@ class GeneralSettingsController {
 		$page_title            = 'Home Settings';
 		$dt_home_require_login = get_plugin_option( 'require_login' );
 		$dt_home_reset_apps    = get_plugin_option( 'reset_apps' );
-        $dt_home_button_color  = get_plugin_option( 'button_color' ) ?? '#3fab3f';
+        $dt_home_button_color  = get_plugin_option( 'button_color' );
 
 		return view( 'settings/general', compact( 'tab', 'link', 'page_title', 'dt_home_require_login', 'dt_home_reset_apps', 'dt_home_button_color' ) );
 	}

--- a/src/Controllers/Admin/GeneralSettingsController.php
+++ b/src/Controllers/Admin/GeneralSettingsController.php
@@ -22,8 +22,9 @@ class GeneralSettingsController {
 		$page_title            = 'Home Settings';
 		$dt_home_require_login = get_plugin_option( 'require_login' );
 		$dt_home_reset_apps    = get_plugin_option( 'reset_apps' );
+        $dt_home_button_color  = get_plugin_option( 'button_color' ) ?? '#3fab3f';
 
-		return view( 'settings/general', compact( 'tab', 'link', 'page_title', 'dt_home_require_login', 'dt_home_reset_apps' ) );
+		return view( 'settings/general', compact( 'tab', 'link', 'page_title', 'dt_home_require_login', 'dt_home_reset_apps', 'dt_home_button_color' ) );
 	}
 
 	/**
@@ -37,9 +38,11 @@ class GeneralSettingsController {
 		$input        = extract_request_input( $request );
 		$require_user = $input['dt_home_require_login'] ?? 'off';
 		$reset_apps   = $input['dt_home_reset_apps'] ?? 'off';
+        $button_color = $input['dt_home_button_color'] ?? '#3fab3f';
 
 		set_plugin_option( 'require_login', $require_user === 'on' );
 		set_plugin_option( 'reset_apps', $reset_apps === 'on' );
+        set_plugin_option( 'button_color', $button_color );
 
 		$redirect_url = add_query_arg( 'message', 'updated', admin_url( 'admin.php?page=dt_home' ) );
 

--- a/src/Controllers/MagicLink/LauncherController.php
+++ b/src/Controllers/MagicLink/LauncherController.php
@@ -32,7 +32,7 @@ class LauncherController {
 		$app_url     = magic_url( '', $key );
 		$magic_link  = $app_url . '/share';
 		$reset_apps  = get_plugin_option( 'reset_apps' );
-        $button_color  = get_plugin_option( 'button_color' ) ?? '#3fab3f';
+        $button_color  = get_plugin_option( 'button_color' );
 		return template(
 			'index',
 			compact(

--- a/src/Controllers/MagicLink/LauncherController.php
+++ b/src/Controllers/MagicLink/LauncherController.php
@@ -32,7 +32,7 @@ class LauncherController {
 		$app_url     = magic_url( '', $key );
 		$magic_link  = $app_url . '/share';
 		$reset_apps  = get_plugin_option( 'reset_apps' );
-
+        $button_color  = get_plugin_option( 'button_color' ) ?? '#3fab3f';
 		return template(
 			'index',
 			compact(
@@ -41,7 +41,8 @@ class LauncherController {
 				'app_url',
 				'magic_link',
 				'hidden_data',
-				'reset_apps'
+				'reset_apps',
+                'button_color'
 			)
 		);
 	}


### PR DESCRIPTION
@incraigulous The feature enabling admins to customize the color of the "+ button" for adding new apps has been successfully implemented. Admins can now effortlessly select and modify the button color using the color picker, providing enhanced flexibility and personalization for the interface.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208217663657696