### PR TITLE
Ensure 'custom_ministry_logo' option returns an empty string if null

### DIFF
--- a/src/Controllers/Admin/GeneralSettingsController.php
+++ b/src/Controllers/Admin/GeneralSettingsController.php
@@ -11,47 +11,50 @@ use function DT\Home\redirect;
 use function DT\Home\set_plugin_option;
 use function DT\Home\view;
 
-class GeneralSettingsController {
-	/**
-	 * Show the general settings admin tab
-	 *
-	 * @return ResponseInterface
-	 */
-	public function show( Request $request ) {
-		$tab                   = 'general';
-		$link                  = 'admin.php?page=dt_home&tab=';
-		$page_title            = 'Home Settings';
-		$dt_home_require_login = get_plugin_option( 'require_login' );
-		$dt_home_reset_apps    = get_plugin_option( 'reset_apps' );
-        $dt_home_show_in_menu  = get_plugin_option( 'show_in_menu' );
-        $dt_home_button_color  = get_plugin_option( 'button_color' );
-        $dt_home_file_upload = get_plugin_option( 'custom_ministry_logo' );
+class GeneralSettingsController
+{
+    /**
+     * Show the general settings admin tab
+     *
+     * @return ResponseInterface
+     */
+    public function show( Request $request )
+    {
+        $tab = 'general';
+        $link = 'admin.php?page=dt_home&tab=';
+        $page_title = 'Home Settings';
+        $dt_home_require_login = get_plugin_option( 'require_login' );
+        $dt_home_reset_apps = get_plugin_option( 'reset_apps' );
+        $dt_home_show_in_menu = get_plugin_option( 'show_in_menu' );
+        $dt_home_button_color = get_plugin_option( 'button_color' );
+        $dt_home_file_upload = get_plugin_option( 'custom_ministry_logo' ) ?? '';
 
-		return view( 'settings/general', compact( 'tab', 'link', 'page_title', 'dt_home_require_login', 'dt_home_reset_apps', 'dt_home_button_color', 'dt_home_show_in_menu', 'dt_home_file_upload' ) );
-	}
+        return view( 'settings/general', compact( 'tab', 'link', 'page_title', 'dt_home_require_login', 'dt_home_reset_apps', 'dt_home_button_color', 'dt_home_show_in_menu', 'dt_home_file_upload' ) );
+    }
 
-	/**
-	 * Update the general settings admin tab
-	 *
-	 * @param Request $request The Request object containing the parsed body data
-	 *
-	 * @return ResponseInterface The redirect response
-	 */
-	public function update( Request $request ) {
-		$input                = extract_request_input( $request );
-		$require_user         = $input['dt_home_require_login'] ?? 'off';
-		$reset_apps           = $input['dt_home_reset_apps'] ?? 'off';
+    /**
+     * Update the general settings admin tab
+     *
+     * @param Request $request The Request object containing the parsed body data
+     *
+     * @return ResponseInterface The redirect response
+     */
+    public function update( Request $request )
+    {
+        $input = extract_request_input( $request );
+        $require_user = $input['dt_home_require_login'] ?? 'off';
+        $reset_apps = $input['dt_home_reset_apps'] ?? 'off';
         $dt_home_show_in_menu = $input['dt_home_show_in_menu'] ?? 'off';
-        $button_color         = $input['dt_home_button_color'] ?? config( 'options.defaults.button_color' );
+        $button_color = $input['dt_home_button_color'] ?? config( 'options.defaults.button_color' );
         $dt_home_file_upload = $input['dt_home_custom_ministry_logo'] ?? '';
-		set_plugin_option( 'require_login', $require_user === 'on' );
-		set_plugin_option( 'reset_apps', $reset_apps === 'on' );
+        set_plugin_option( 'require_login', $require_user === 'on' );
+        set_plugin_option( 'reset_apps', $reset_apps === 'on' );
         set_plugin_option( 'button_color', $button_color );
         set_plugin_option( 'show_in_menu', $dt_home_show_in_menu === 'on' );
         set_plugin_option( 'custom_ministry_logo', $dt_home_file_upload );
 
-		$redirect_url = add_query_arg( 'message', 'updated', admin_url( 'admin.php?page=dt_home' ) );
+        $redirect_url = add_query_arg( 'message', 'updated', admin_url( 'admin.php?page=dt_home' ) );
 
-		return redirect( $redirect_url );
-	}
+        return redirect( $redirect_url );
+    }
 }

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -100,7 +100,7 @@ class RegisterController {
         $page_title   = __( 'Register', 'dt-home' );
         $dt_home_file_upload = get_plugin_option( 'custom_ministry_logo' );
 
-      return template( 'auth/register', [
+    return template( 'auth/register', [
 
             'form_action' => $form_action,
             'login_url'   => $login_url,
@@ -111,6 +111,6 @@ class RegisterController {
             'error'       => $error,
             'page_title'  => $page_title,
             'custom_ministry_logo' => $dt_home_file_upload,
-        ] );
+    ] );
     }
 }


### PR DESCRIPTION
 Added null coalescing operator (??) to handle the case where the 'custom_ministry_logo' option is null, defaulting to an empty string and fix Correct multi-line function call indentation in RegisterController.php file