### PR TITLE
Fix: Import missing class for extract_request_input() in LoginController

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -6,6 +6,7 @@ use DT\Home\CodeZone\WPSupport\Router\ServerRequestFactory;
 use DT\Home\GuzzleHttp\Psr7\ServerRequest as Request;
 use DT\Home\Psr\Http\Message\ResponseInterface;
 use function DT\Home\get_plugin_option;
+use function DT\Home\extract_request_input;
 use function DT\Home\plugin_url;
 use function DT\Home\redirect;
 use function DT\Home\route_url;
@@ -16,7 +17,8 @@ use function DT\Home\template;
  *
  * This class handles user login and authentication.
  */
-class LoginController {
+class LoginController
+{
 
     /**
      * Process the login form submission.
@@ -24,34 +26,35 @@ class LoginController {
      * @param Request $request The request object.
      * @return ResponseInterface The response object based on the login result.
      */
-	public function process( Request $request ) {
-		global $errors;
+    public function process( Request $request )
+    {
+        global $errors;
 
-		$params = extract_request_input( $request );
-		$user = wp_authenticate( $params['username'] ?? '', $params['password'] ?? '' );
+        $params = extract_request_input( $request );
+        $user = wp_authenticate( $params['username'] ?? '', $params['password'] ?? '' );
 
-		if ( is_wp_error( $user ) ) {
-			//phpcs:ignore
-			$errors = $user;
-			$error  = $errors->get_error_message();
-			$error  = apply_filters( 'login_errors', $error );
+        if ( is_wp_error( $user ) ) {
+            //phpcs:ignore
+            $errors = $user;
+            $error = $errors->get_error_message();
+            $error = apply_filters( 'login_errors', $error );
 
-			//If the error links to lost password, inject the 3/3rds redirect
-			$error = str_replace( '?action=lostpassword', '?action=lostpassword?&redirect_to=/', $error );
+            //If the error links to lost password, inject the 3/3rds redirect
+            $error = str_replace( '?action=lostpassword', '?action=lostpassword?&redirect_to=/', $error );
 
-			return $this->show_error( $error );
-		}
+            return $this->show_error( $error );
+        }
 
-		wp_set_auth_cookie( $user->ID );
+        wp_set_auth_cookie( $user->ID );
 
-		if ( ! $user ) {
-			return $this->show_error( __( 'An unexpected error has occurred.', 'dt-home' ) );
-		}
+        if ( !$user ) {
+            return $this->show_error( __( 'An unexpected error has occurred.', 'dt-home' ) );
+        }
 
-		wp_set_current_user( $user->ID );
+        wp_set_current_user( $user->ID );
 
-		return redirect( route_url() );
-	}
+        return redirect( route_url() );
+    }
 
     /**
      * Show the login page with an error.
@@ -63,11 +66,12 @@ class LoginController {
      * @param array $headers The headers for the request.
      * @return ResponseInterface The response of the request.
      */
-    private function show_error( $error, $params = [], $method = "GET", $endpoint = "", $headers = [
+    private function show_error($error, $params = [], $method = "GET", $endpoint = "", $headers = [
         'Content-Type' => 'application/HTML',
-    ]): ResponseInterface {
+    ]): ResponseInterface
+    {
         $params = array_merge( $params, [ 'error' => $error ] );
-        if ( ! empty( $endpoint ) ) {
+        if ( !empty( $endpoint ) ) {
             $endpoint = route_url( 'login' );
         }
         return $this->show( ServerRequestFactory::request( $method, $endpoint, $params, $headers ) );
@@ -79,29 +83,30 @@ class LoginController {
      * @param Request $request The request object.
      * @return ResponseInterface The response object containing the login form template.
      */
-    public function show( Request $request ) {
-        $params       = extract_request_input( $request );
+    public function show( Request $request )
+    {
+        $params = extract_request_input( $request );
         $register_url = route_url( 'register' );
-        $form_action  = route_url( 'login' );
-        $username     = sanitize_text_field( $params['username'] ?? '' );
-        $password     = sanitize_text_field( $params['password'] ?? '' );
-        $error        = sanitize_text_field( $params['error'] ?? '' );
-        $logo_path    = plugin_url( 'resources/img/logo-color.png' );
-        $reset_url    = wp_lostpassword_url( plugin_url() );
-        $page_title   = __( 'Login', 'dt-home' );
+        $form_action = route_url( 'login' );
+        $username = sanitize_text_field( $params['username'] ?? '' );
+        $password = sanitize_text_field( $params['password'] ?? '' );
+        $error = sanitize_text_field( $params['error'] ?? '' );
+        $logo_path = plugin_url( 'resources/img/logo-color.png' );
+        $reset_url = wp_lostpassword_url( plugin_url() );
+        $page_title = __( 'Login', 'dt-home' );
         $dt_home_file_upload = get_plugin_option( 'custom_ministry_logo' );
 
-        return template( 'auth/login', [
+        return template('auth/login', [
             'register_url' => $register_url,
-            'form_action'  => $form_action,
-            'username'     => $username,
-            'password'     => $password,
-            'logo_path'    => $logo_path,
-            'reset_url'    => $reset_url,
-            'error'        => $error,
-            'page_title'   => $page_title,
+            'form_action' => $form_action,
+            'username' => $username,
+            'password' => $password,
+            'logo_path' => $logo_path,
+            'reset_url' => $reset_url,
+            'error' => $error,
+            'page_title' => $page_title,
             'custom_logo' => $dt_home_file_upload,
-        ] );
+        ]);
     }
 
     /**
@@ -109,9 +114,10 @@ class LoginController {
      *
      * @return ResponseInterface The response object redirecting to the login page.
      */
-	public function logout() {
-		wp_logout();
+    public function logout()
+    {
+        wp_logout();
 
-		return redirect( route_url( 'login' ) );
-	}
+        return redirect( route_url( 'login' ) );
+    }
 }


### PR DESCRIPTION
Hey @incraigulous ,

I’ve addressed the undefined function error by importing the correct class in the LoginController. This resolves the unit test failures caused by the missing extract_request_input() function.