### PR TITLE
Fix AppControllerTest::it_renders() failing test

### DIFF
--- a/tests/AppControllerTest.php
+++ b/tests/AppControllerTest.php
@@ -6,7 +6,6 @@ use DT\Home\CodeZone\WPSupport\Router\ServerRequestFactory;
 use DT\Home\Controllers\MagicLink\AppController;
 use DT\Home\Services\Apps;
 use function DT\Home\container;
-use function DT\Home\set_plugin_option;
 
 class AppControllerTest extends TestCase
 {
@@ -72,11 +71,9 @@ class AppControllerTest extends TestCase
         $user_id = 1;
         $this->acting_as( $user_id );
 
-        $data = app_factory([
-            'is_hidden' => true
-        ]);
-
-        set_plugin_option( 'apps', [ $data ] );
+        $apps_service = container()->get( Apps::class );
+        $apps = $apps_service->for( $user_id );
+        $data = $apps[0];
 
         $request = ServerRequestFactory::request( 'POST', 'apps/launcher/key/un-hide-app', $data );
         $key = $this->faker->md5;

--- a/tests/AppControllerTest.php
+++ b/tests/AppControllerTest.php
@@ -13,7 +13,8 @@ class AppControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_missing_apps() {
+    public function it_handles_missing_apps()
+    {
         $request = ServerRequestFactory::from_globals();
         $app = app_factory();
         $controller = container()->get( AppController::class );
@@ -24,15 +25,21 @@ class AppControllerTest extends TestCase
     /**
      * @test
      *
-    public function it_renders() {
+     */
+    public function it_renders()
+    {
+        $user_id = 1;
+        $this->acting_as( $user_id );
         $request = ServerRequestFactory::from_globals();
         $app = app_factory([
             'creation_type' => 'custom',
         ]);
         $apps = container()->get( Apps::class );
         $data = $apps->from( 'settings' );
+
         $data[] = $app;
-        set_plugin_option( 'apps', $data );
+
+        update_user_option( $user_id, 'dt_home_apps', $data );
         $controller = container()->get( AppController::class );
         $response = $controller->show( $request, [ 'slug' => $app['slug'] ] );
         $this->assertEquals( 200, $response->getStatusCode() );
@@ -40,9 +47,16 @@ class AppControllerTest extends TestCase
 
     /**
      * @test
-     *
-    public function it_can_hide_apps() {
-        $data = app_factory();
+     */
+    public function it_can_hide_apps()
+    {
+        $user_id = 1;
+        $this->acting_as( $user_id );
+
+        $apps_service = container()->get( Apps::class );
+        $apps = $apps_service->for( $user_id );
+        $data = $apps[0];
+
         $request = ServerRequestFactory::request( 'POST', 'apps/launcher/key/update-hide-apps', $data );
         $key = $this->faker->md5;
         $controller = container()->get( AppController::class );
@@ -52,13 +66,24 @@ class AppControllerTest extends TestCase
 
     /**
      * @test
-     *
-    public function it_can_unhide_apps() {
-        $data = app_factory();
+     */
+    public function it_can_unhide_apps(): void
+    {
+        $user_id = 1;
+        $this->acting_as( $user_id );
+
+        $data = app_factory([
+            'is_hidden' => true
+        ]);
+
+        set_plugin_option( 'apps', [ $data ] );
+
         $request = ServerRequestFactory::request( 'POST', 'apps/launcher/key/un-hide-app', $data );
         $key = $this->faker->md5;
         $controller = container()->get( AppController::class );
         $response = $controller->unhide( $request, [ 'key' => $key ] );
+
+
         $this->assertEquals( 200, $response->getStatusCode() );
     }
 


### PR DESCRIPTION
@incraigulous I’ve resolved the issues with the AppControllerTest::it_renders(), AppControllerTest::it_can_hide_apps(), and AppControllerTest::it_can_unhide_apps() methods.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208469627968100