### PR TITLE
Set the Disciple Tool chevron images to default.

### DIFF
--- a/resources/js/components/app-grid.js
+++ b/resources/js/components/app-grid.js
@@ -828,6 +828,7 @@ class AppGrid extends LitElement {
                                     class="app-grid__icon"
                                     name="${app.name}"
                                     icon="${app.icon}"
+                                    slug="${app.slug}"
                                 ></dt-home-app-icon>
                             </div>
                         `


### PR DESCRIPTION
Hey @incraigulous, I noticed that during the conflicts we faced earlier, this line was missing. I've added it now, and everything is working.