### PR TITLE
WIP - D.T Home: #333 - Investigate Bug Preventing Magic Link App URL Field Updates

### DIFF
--- a/src/Services/Apps.php
+++ b/src/Services/Apps.php
@@ -294,7 +294,7 @@ class Apps {
 
         //If the existing app is a coded app, we need to keep the url and magic link meta
         $overrides = [
-            'url' => $existing['url'] ?? ''
+            //'url' => $existing['url'] ?? ''
         ];
         if ( isset( $app['magic_link_meta'] ) ) {
             $overrides['magic_link_meta'] = $app['magic_link_meta'];


### PR DESCRIPTION
- fixes: #333 
---

> With regards to Magic Link Coded Apps; this is only part of the fix; due to the dynamic nature of how Magic Links are constructed. Due to it's dependence on the [site_url()](https://developer.wordpress.org/reference/functions/site_url/) function; administrators must ensure, [valid Wordpress Site URLs have been specified](https://kinsta.com/blog/wordpress-change-url/#change-wordpress-url-via-the-admin-dashboard); as this value will be dynamically prefixed with app's Magic Link path and id, upon construction.